### PR TITLE
Update get_updates.sh to get rid of deprecated `set-output`

### DIFF
--- a/run/get_updates.sh
+++ b/run/get_updates.sh
@@ -47,7 +47,7 @@ exit_no_commits() {
 }
 
 set_out_put() {
-    echo "::set-output name=has_new_commits::${HAS_NEW_COMMITS}"
+    echo "has_new_commits=${HAS_NEW_COMMITS}" >> $GITHUB_OUTPUT
 }
 
 find_last_synced_commit() {


### PR DESCRIPTION
In reference with https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ the 
```
echo "::set-output name=has_new_commits::${HAS_NEW_COMMITS}"
```
replaced by 
```
echo "has_new_commits=${HAS_NEW_COMMITS}" >> $GITHUB_OUTPUT
```